### PR TITLE
Ruleset for pokemons that consist one of these given types [Fire, Water, Grass]

### DIFF
--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -5,6 +5,7 @@
             "maxLevel": 100,
             "minPokemon": 4,
             "maxPokemon": 6,
+            "allowedgens": [],
             "legal": {
                 "types": ["Fire","Water","Grass"],
                 "species": [],

--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -1,0 +1,38 @@
+{
+    "1296492335529463919": {
+        "pokemon": {
+            "minLevel": 90,
+            "maxLevel": 100,
+            "minPokemon": 4,
+            "maxPokemon": 6,
+            "legal": {
+                "types": ["Fire","Water","Grass"],
+                "species": [],
+                "rarity": ["common","regional","ultrabeast","special","mythical"]
+            },
+            "illegal": {
+                "types": ["Ground"],
+                "species": [],
+                "rarity": []
+            }
+        },
+        "moves": {
+            "legal": {
+                "types": [],
+                "names": []
+            },
+            "illegal": {
+                "types": [],
+                "names": ["baton-pass","minimize","double-team"]
+            }
+        },
+        "abilities": {
+            "legal": [],
+            "illegal": ["Shadow Tag","Sand Veil","Snow Cloak","Orichalcum Pulse","Hadron Engine","Arena Trap","Multitype"]
+        },
+        "items": {
+            "legal": [],
+            "illegal": ["leftovers","shell-bell","black-sludge"]
+        }
+    }
+}

--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -5,7 +5,7 @@
             "maxLevel": 100,
             "minPokemon": 4,
             "maxPokemon": 6,
-            "allowedgens": [],
+            "allowedGens": [],
             "legal": {
                 "types": ["Fire","Water","Grass"],
                 "species": [],


### PR DESCRIPTION
These rulesets are for Pokemon that have a combination of types with the given list [Fire, Water, Grass] of all generations
all ground type pokemon are considered illegal
all rarities except legendaries are legal except for [Miraidon, Koraidon, Arceus] which are considered illegal
Baton-pass, evasion-boosting moves and abilities are illegal.