### PR TITLE
added generation limit, added paradox

### DIFF
--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -5,11 +5,11 @@
             "maxLevel": 100,
             "minPokemon": 4,
             "maxPokemon": 6,
-            "allowedGens": [],
+            "allowedGens": [1,2,3,4,6,7,8,9],
             "legal": {
                 "types": ["Fire","Water","Grass"],
                 "species": [],
-                "rarity": ["common","regional","ultrabeast","special","mythical"]
+                "rarity": ["common","regional","ultrabeast","special","mythical","paradox"]
             },
             "illegal": {
                 "types": ["Ground"],


### PR DESCRIPTION
pokemon from Generation 5 is now illegal, paradox rarity is now legal.