### PR TITLE
Ruleset for test channel was added.

### DIFF
--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -1,7 +1,7 @@
 {
-    "1296492335529463919": {
+    "1257054038332276860": {
         "pokemon": {
-            "minLevel": 90,
+            "minLevel": 1,
             "maxLevel": 100,
             "minPokemon": 1,
             "maxPokemon": 6,
@@ -14,6 +14,43 @@
             "illegal": {
                 "types": ["Ground"],
                 "species": ["Charizard"],
+                "rarity": []
+            }
+        },
+        "moves": {
+            "legal": {
+                "types": [],
+                "names": []
+            },
+            "illegal": {
+                "types": [],
+                "names": ["baton-pass","minimize","double-team"]
+            }
+        },
+        "abilities": {
+            "legal": [],
+            "illegal": ["Shadow Tag","Sand Veil","Snow Cloak","Orichalcum Pulse","Hadron Engine","Arena Trap","Multitype"]
+        },
+        "items": {
+            "legal": [],
+            "illegal": ["leftovers","shell-bell","black-sludge"]
+        }
+    },
+    "1296492335529463919": {
+        "pokemon": {
+            "minLevel": 90,
+            "maxLevel": 100,
+            "minPokemon": 3,
+            "maxPokemon": 6,
+            "allowedGens": [],
+            "legal": {
+                "types": ["Fire","Water","Grass"],
+                "species": [],
+                "rarity": ["common","regional","special","mythical","paradox"]
+            },
+            "illegal": {
+                "types": ["Ground"],
+                "species": [],
                 "rarity": []
             }
         },

--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -1,5 +1,6 @@
 {
     "1257054038332276860": {
+        "description": "This is for the test channel",
         "pokemon": {
             "minLevel": 1,
             "maxLevel": 100,
@@ -37,6 +38,7 @@
         }
     },
     "1296492335529463919": {
+        "description":"Thread: Custom Battle #1",
         "pokemon": {
             "minLevel": 90,
             "maxLevel": 100,

--- a/rulesets/333749099897683980.json
+++ b/rulesets/333749099897683980.json
@@ -13,7 +13,7 @@
             },
             "illegal": {
                 "types": ["Ground"],
-                "species": [],
+                "species": ["Charizard"],
                 "rarity": []
             }
         },


### PR DESCRIPTION
added a brief description to which ID's correspond to their channels or usage
added test channel with a [charizard] as an illegal pokemon.